### PR TITLE
Package Coquelicot 2.0.1.

### DIFF
--- a/packages/coquelicot.2.0.1/descr
+++ b/packages/coquelicot.2.0.1/descr
@@ -1,0 +1,1 @@
+A Coq formalization of real analysis compatible with the standard library.

--- a/packages/coquelicot.2.0.1/opam
+++ b/packages/coquelicot.2.0.1/opam
@@ -1,0 +1,8 @@
+opam-version: "1.1"
+maintainer: "guillaume.melquiond@inria.fr"
+build: [
+  ["./configure"]
+  ["./remake" "-j%{jobs}%"]
+  ["./remake" "install"]
+]
+depends: ["coq" {>= "8.4.2"} "ssreflect" ]

--- a/packages/coquelicot.2.0.1/url
+++ b/packages/coquelicot.2.0.1/url
@@ -1,0 +1,1 @@
+archive: "https://gforge.inria.fr/frs/download.php/33464/coquelicot-2.0.1.tar.gz"


### PR DESCRIPTION
A last minute change in Ssreflect 1.5 broke Coquelicot, so here is a new version.

I don't know what is the Opam policy about obsolete packages. Should I just remove the Coquelicot 2.0.0 directory?
