### PR TITLE
Add package for Coquelicot 2.1.0.

### DIFF
--- a/packages/coq:coquelicot/coq:coquelicot.2.1.0/descr
+++ b/packages/coq:coquelicot/coq:coquelicot.2.1.0/descr
@@ -1,0 +1,1 @@
+A Coq formalization of real analysis compatible with the standard library.

--- a/packages/coq:coquelicot/coq:coquelicot.2.1.0/opam
+++ b/packages/coq:coquelicot/coq:coquelicot.2.1.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.1"
+maintainer: "guillaume.melquiond@inria.fr"
+homepage: "http://coquelicot.saclay.inria.fr/"
+license: "LGPL 3"
+build: [
+  ["./configure"]
+  ["./remake" "-j%{jobs}%"]
+  ["./remake" "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coquelicot"]
+depends: [
+  "coq" {>= "8.4pl4"}
+  "coq:ssreflect" {>= "1.5.0"}
+]

--- a/packages/coq:coquelicot/coq:coquelicot.2.1.0/url
+++ b/packages/coq:coquelicot/coq:coquelicot.2.1.0/url
@@ -1,0 +1,2 @@
+http: "https://gforge.inria.fr/frs/download.php/file/34663/coquelicot-2.1.0.tar.gz"
+checksum: "eac4d9717150b22a416b4b286ff3d9db"


### PR DESCRIPTION
Note that it is compatible with both Coq 8.4 and 8.5.