### PR TITLE
MacOS case-insensitive file system compatibility

### DIFF
--- a/packages/coq:color/coq:color.1.1.0/opam
+++ b/packages/coq:color/coq:color.1.1.0/opam
@@ -4,7 +4,7 @@ homepage: "http://color.inria.fr/"
 license: "CeCILL"
 build: [
   [make "-j%{jobs}%"]
-  [make "install"]
+  [make -f Makefile.coq "install"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CoLoR"]
 depends: [

--- a/packages/coq:color/coq:color.1.1.0/opam
+++ b/packages/coq:color/coq:color.1.1.0/opam
@@ -4,7 +4,7 @@ homepage: "http://color.inria.fr/"
 license: "CeCILL"
 build: [
   [make "-j%{jobs}%"]
-  [make "-f Makefile.coq" "install"]
+  [make "-f" "Makefile.coq" "install"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CoLoR"]
 depends: [

--- a/packages/coq:color/coq:color.1.1.0/opam
+++ b/packages/coq:color/coq:color.1.1.0/opam
@@ -4,7 +4,7 @@ homepage: "http://color.inria.fr/"
 license: "CeCILL"
 build: [
   [make "-j%{jobs}%"]
-  [make -f Makefile.coq "install"]
+  [make "-f Makefile.coq" "install"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CoLoR"]
 depends: [


### PR DESCRIPTION
Problem: installing coq:color via OPAM under MacOS seemingly succeeds, but library files are not installed. The reason for this is ‘make install’ makefile goal does nothing as the distribution contains file INSTALL.
Under case-insensitive file system it matches goal ‘install’, so ‘make' finds it and considers goal up to date and never actually copy any files. Illustration:

lambda13 ~/tmp/color.1.1.0$ make install
make: `install' is up to date.
lambda13 ~/tmp/color.1.1.0$ ls -l INSTALL
-rw-r----- 1 lord staff 1377 Mar 10 09:41 INSTALL
lambda13 ~/tmp/color.1.1.0$ ls -l install
-rw-r----- 1 lord staff 1377 Mar 10 09:41 install

Current solution was proposed by Matthieu Sozeau in coq-club mailing lists.
